### PR TITLE
Fix issues with argument escaping in cifs.sh

### DIFF
--- a/cifs.sh
+++ b/cifs.sh
@@ -35,11 +35,11 @@ usage() {
 }
 
 err() {
-	echo -e $* 1>&2
+	echo -e "$@" 1>&2
 }
 
 log() {
-	echo -e $* >&1
+	echo -e "$@" >&1
 }
 
 ismounted() {
@@ -121,17 +121,17 @@ shift
 
 case "$op" in
         attach)
-                attach $*
+                attach "$@"
                 ;;
         detach)
-                detach $*
+                detach "$@"
                 ;;
         mount)
-                domount $*
+                domount "$@"
                 ;;
 	unmount)
-		unmount $*
-		;;
+                unmount "$@"
+                ;;
 	*)
 		usage
 esac


### PR DESCRIPTION
This PR fixes issue with shell argument escaping.

When the CIFS source argument contains a space, the mount fails. And it will probably fail if any of the other arguments contains a space (for example the fsType).

The reason is that when invoking is invoked with cifs.sh the mount action, `$3` which contains the json options is broken into `$3` and `$4` in the switch that runs the domount() function. As a result, the JQ parsing of `$3` fails silently (`$3` is invalid JSON document since the missing part is in `$4`), then the mount ultimately fails.

How to reproduce:
```sh
./cifs.sh \
  mount \
  /mnt \
  /dev/null \
 '{"kubernetes.io/fsType":"","mountOptions":"","source":"//192.168.56.101/shared space"}'
```